### PR TITLE
[Android bug] Preventing possible U+00AD crash.

### DIFF
--- a/app/src/main/java/com/daquexian/chaoli/forum/meta/PostContentView.java
+++ b/app/src/main/java/com/daquexian/chaoli/forum/meta/PostContentView.java
@@ -53,7 +53,7 @@ public class PostContentView extends LinearLayout {
         mAttachmentList = post.getAttachments();
         List<Post.Attachment> attachmentList = new ArrayList<>(post.getAttachments());
         String content = post.getContent();
-        ocntent = content.replaceAll("\u00AD", "");
+        content = content.replaceAll("\u00AD", "");
         Matcher attachmentMatcher = ATTACHMENT_PATTERN.matcher(content);
         while (attachmentMatcher.find()) {
             String id = attachmentMatcher.group(1);

--- a/app/src/main/java/com/daquexian/chaoli/forum/meta/PostContentView.java
+++ b/app/src/main/java/com/daquexian/chaoli/forum/meta/PostContentView.java
@@ -53,7 +53,7 @@ public class PostContentView extends LinearLayout {
         mAttachmentList = post.getAttachments();
         List<Post.Attachment> attachmentList = new ArrayList<>(post.getAttachments());
         String content = post.getContent();
-
+        ocntent = content.replaceAll("\u00AD", "");
         Matcher attachmentMatcher = ATTACHMENT_PATTERN.matcher(content);
         while (attachmentMatcher.find()) {
             String id = attachmentMatcher.group(1);


### PR DESCRIPTION
Character U+00AD(SOFT HYPHEN), an unprintable character, was found making crash in WeChat on some Android devices.
This issue was directly reported to engineer of WeChat for Android. It was found that this bug should blame TextView in Android 6.0, not WeChat, on the next day. QQ has a small probability of reappearing this issue, remaining unreported.
Minimum test case of reappearing this crash is still making, prevents reporting to Android Issue Tracker.
A small application with just a Textview setting text or / and title "\u00ad" WON'T make this application to crash, which makes this issue more complex.
WeChat temporarily preventing this crash by a try-catch background check, since they didn't find any further information about this bug on the log and Google.(In short, they got the log, but they don't know why.)
It seems to make a similar check on this project, before any real reason found or any patches released, is a good choice, avoiding any possible unfriendly use of this issue.
Whether any other special character making a similar crash remains unknown.